### PR TITLE
Fixing compilation of GCC 8.1+

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -35,5 +35,5 @@ ifeq ($(UNAME_SYS), darwin)
 				-Wl,-U,_enif_mutex_unlock
 endif
 
-CXXFLAGS+=  -g -Wextra -Werror -Wno-missing-field-initializers -fno-rtti -fno-exceptions
+CXXFLAGS+=  -g -Wextra -Werror -Wno-missing-field-initializers -fno-rtti -fno-exceptions -Wno-ignored-qualifiers
 LDFLAGS +=  -lstdc++


### PR DESCRIPTION
Compilation on newer versions of GCC fails and requires the
-Wno-ignored-qualifiers flag.

Tested on GCC 8.3.1 and 9.1.1.